### PR TITLE
Add a permanent shop mode to the show case

### DIFF
--- a/java/defeatedcrow/showcase/blocks/BlockShowcase.java
+++ b/java/defeatedcrow/showcase/blocks/BlockShowcase.java
@@ -34,7 +34,7 @@ public class BlockShowcase extends BlockContainer {
 
 	protected Random rand = new Random();
 
-	private String[] modeName = new String[] { "Public", "Private", "Villager", "Display-only" };
+	private String[] modeName = new String[] { "Public", "Private", "Villager", "Display-only", "Permanent Shop" };
 
 	public BlockShowcase() {
 		super(Material.clay);
@@ -109,7 +109,7 @@ public class BlockShowcase extends BlockContainer {
 
 								player.addChatMessage(MessageUtil.ItemCancel(ret));
 
-							} else if (mode < 2) { // 購入
+							} else if (mode != 3) { // 購入
 								int require = MPChecker.getSellMP(sellItem);
 								int playerMP = MPChecker.PlayerMP(player);
 
@@ -120,14 +120,18 @@ public class BlockShowcase extends BlockContainer {
 									int get = MCEconomyAPI.reducePlayerMP(player, require, false);
 									this.dropSellItem(world, player, ret);
 
-									tile.getInv().setInventorySlotContents(1, (ItemStack) null);
-									tile.addMP(require);
+									if (mode != 4) {
+										tile.getInv().setInventorySlotContents(1, (ItemStack) null);
+										tile.addMP(require);
+									}
 
 									player.addChatMessage(MessageUtil.boughtItem(sellItem, currentOwner));
 
-									EntityPlayer ownerPlayer = world.getPlayerEntityByName(currentOwner);
-									if (ownerPlayer != null) {
-										ownerPlayer.addChatMessage(MessageUtil.boughtYourItem(sellItem, name));
+									if (mode != 4) {
+										EntityPlayer ownerPlayer = world.getPlayerEntityByName(currentOwner);
+										if (ownerPlayer != null) {
+											ownerPlayer.addChatMessage(MessageUtil.boughtYourItem(sellItem, name));
+										}
 									}
 
 									tile.markDirty();
@@ -188,7 +192,7 @@ public class BlockShowcase extends BlockContainer {
 							player.addChatMessage(MessageUtil.ItemCancel(ret));
 						} else { // モード変更
 							int next = mode + 1;
-							if (next > 3)
+							if (next > 4)
 								next = 0;
 							tile.setMode(next);
 							player.addChatMessage(MessageUtil.modeChange(modeName[next]));

--- a/java/defeatedcrow/showcase/client/ClientProxy.java
+++ b/java/defeatedcrow/showcase/client/ClientProxy.java
@@ -1,5 +1,6 @@
 package defeatedcrow.showcase.client;
 
+import defeatedcrow.showcase.common.ShowcaseConfig;
 import net.minecraft.world.World;
 
 import org.lwjgl.input.Keyboard;
@@ -41,7 +42,7 @@ public class ClientProxy extends CommonProxy {
 
 	@Override
 	public boolean getOP(String name) {
-		return false;
+		return  ShowcaseConfig.spIsOp;
 	}
 
 }

--- a/java/defeatedcrow/showcase/common/CommonProxy.java
+++ b/java/defeatedcrow/showcase/common/CommonProxy.java
@@ -39,6 +39,8 @@ public class CommonProxy {
 					SCLogger.debugInfo("Server OP was detected. " + op);
 				return true;
 			}
+		} else {
+			return ShowcaseConfig.spIsOp;
 		}
 		return false;
 	}

--- a/java/defeatedcrow/showcase/common/ShowcaseConfig.java
+++ b/java/defeatedcrow/showcase/common/ShowcaseConfig.java
@@ -12,6 +12,7 @@ public class ShowcaseConfig {
 	private final String BR = System.getProperty("line.separator");
 
 	public static String[] mpList = { "DCsAppleMilk:defeatedcrow.clam:0:50" };
+	public static boolean spIsOp = false;
 
 	public void load(Configuration cfg) {
 		try {
@@ -24,10 +25,13 @@ public class ShowcaseConfig {
 
 			mpList = mpListP.getStringList();
 
+			spIsOp = cfg.getBoolean("spIsOP", "general", false, "Determines if the player in single player is always considered an OP. Only use for making maps.");
+
 		} catch (Exception e) {
 			e.printStackTrace();
 		} finally {
-			cfg.save();
+			if (cfg.hasChanged())
+				cfg.save();
 		}
 	}
 


### PR DESCRIPTION
This allows an OP to set a show case to permanent shop mode. The item can be bought indefinitely and no MP are accumulated in the show case.
The mode is useful for maps or to make a community shop on servers. To allow map creation in SSP I also added an option to allow the player OP access.

There are more ideas I have, but I want to discuss them first with you. I will open an issue for that.
